### PR TITLE
fix: import FlowResponse as type in controller

### DIFF
--- a/src/social-posts/social-posts.controller.ts
+++ b/src/social-posts/social-posts.controller.ts
@@ -4,7 +4,8 @@ import { RecordEngagementDto } from './dto/record-engagement.dto';
 import { SchedulePostDto } from './dto/schedule-post.dto';
 import { UploadMediaDto } from './dto/upload-media.dto';
 import { WriteDescriptionDto } from './dto/write-description.dto';
-import { FlowResponse, SocialPostsService } from './social-posts.service';
+import { SocialPostsService } from './social-posts.service';
+import type { FlowResponse } from './social-posts.service';
 
 @Controller('social-posts')
 export class SocialPostsController {


### PR DESCRIPTION
## Summary
- import FlowResponse as a type-only dependency in the social posts controller to satisfy isolated module metadata requirements

## Testing
- pnpm build *(fails: `Cannot find module 'class-validator'` because dependencies such as `class-transformer` cannot be downloaded in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd675c1f18832d8f044e35ac24bab8